### PR TITLE
Add acknowledgements section

### DIFF
--- a/content/02.back-matter.md
+++ b/content/02.back-matter.md
@@ -1,1 +1,10 @@
+# Acknowledgements
+
+We'd like to thank the individuals, not listed as authors, who provided comments on [GitHub issues](https://github.com/greenelab/scihub/issues) or pull requests.
+Specifically, the following individuals provided valuable input while the study was underway:
+[Richard Smith-Unna](https://github.com/blahah),
+[Ross Mounce](https://github.com/rossmounce),
+and [Guillaume Cabanac](https://github.com/gcabanac).
+In addition, we're grateful to GitHub for offering gratis Large File Storage as part of their education program.
+
 # References


### PR DESCRIPTION
This is a proposed acknowledgements section for our manuscript which we'd like to submit to PeerJ Preprints on Monday. @cgreene mentioned that their is a custom to seek approval before mentioning an individual in acknowledgements. While I disagree with this practice, since the contributions were made publicly and our appreciation stands regardless, I thought we might as well ask.

@blahah @rossmounce @gcabanac: please respond whether or not you are okay with being acknowledged in the following way.