### PR TITLE
Add sci-hub.ac domain name

### DIFF
--- a/content/01.manuscript.md
+++ b/content/01.manuscript.md
@@ -35,7 +35,7 @@ Users of Sci-Hub do so at their own risk.
 This study is not an endorsement of using Sci-Hub, and its authors and publishers accept no responsibility on behalf of readers.
 It is a strong possibility that Sci-Hub users — especially those not using privacy-protecting services such as Tor — could have their usage history unmasked and face consequences, both legal or reputational in nature.**
 
-Sci-Hub is currently served at the domains `sci-hub.cc`, `sci-hub.io`, and `scihub22266oqcxt.onion` (a Tor Hidden Service [@url:http://www.dtic.mil/docs/citations/ADA465464]).
+Sci-Hub is currently served at the domains `sci-hub.cc`, `sci-hub.io`, `sci-hub.ac`, and `scihub22266oqcxt.onion` (a Tor Hidden Service [@url:http://www.dtic.mil/docs/citations/ADA465464]).
 Elbakyan recently described the project's technical scope [@url:https://engineuring.wordpress.com/2017/07/02/some-facts-on-sci-hub-that-wikipedia-gets-wrong/]:
 
 > Sci-Hub technically is by itself a repository, or a library if you like, and not a search engine for some other repository.


### PR DESCRIPTION
I saw sci-hub.ac for the first time in https://twitter.com/SimonXIX/status/886209236606357504.
Not sure how long this URL has been in existence.

Both https://sci-hub.ac/ and http://sci-hub.ac/ resolve without error.