### PR TITLE
Acknowledgements: reorder & add Munro

### DIFF
--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -2,7 +2,7 @@
 
 We'd like to thank the individuals, not listed as authors, who provided comments on [GitHub issues](https://github.com/search?utf8=%E2%9C%93&q=repo%3Agreenelab%2Fscihub+repo%3Agreenelab%2Fscihub-manuscript+repo%3Agreenelab%2Fscihub-browser-data+repo%3Adhimmel%2Fjournalmetrics&type=Issues "GitHub Issues in Project Repositories") or pull requests.
 Specifically, the following individuals provided valuable input while the study was underway:
-[Thomas Munro](https://github.com/tamunro) and by extension his [appointment](http://www.deakin.edu.au/about-deakin/people/thomas-munro) at Deakin University, [Ross Mounce](https://github.com/rossmounce), [Richard Smith-Unna](https://github.com/blahah), and [Guillaume Cabanac](https://github.com/gcabanac).
+[Thomas Munro](https://github.com/tamunro) (Deakin University), [Ross Mounce](https://github.com/rossmounce), [Richard Smith-Unna](https://github.com/blahah), and [Guillaume Cabanac](https://github.com/gcabanac).
 In addition, we're grateful to GitHub for offering gratis Large File Storage as part of their education program.
 
 ## References {.page_break_before}

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -1,6 +1,6 @@
 ## Acknowledgements
 
-We'd like to thank the individuals, not listed as authors, who provided comments on [GitHub issues](https://github.com/greenelab/scihub/issues) or pull requests.
+We'd like to thank the individuals, not listed as authors, who provided comments on [GitHub issues](https://github.com/search?utf8=%E2%9C%93&q=repo%3Agreenelab%2Fscihub+repo%3Agreenelab%2Fscihub-manuscript+repo%3Agreenelab%2Fscihub-browser-data+repo%3Adhimmel%2Fjournalmetrics&type=Issues "GitHub Issues in Project Repositories") or pull requests.
 Specifically, the following individuals provided valuable input while the study was underway:
 [Thomas Munro](https://github.com/tamunro) and by extension his [appointment](http://www.deakin.edu.au/about-deakin/people/thomas-munro) at Deakin University, [Ross Mounce](https://github.com/rossmounce), [Richard Smith-Unna](https://github.com/blahah), and [Guillaume Cabanac](https://github.com/gcabanac).
 In addition, we're grateful to GitHub for offering gratis Large File Storage as part of their education program.

--- a/content/99.back-matter.md
+++ b/content/99.back-matter.md
@@ -2,9 +2,7 @@
 
 We'd like to thank the individuals, not listed as authors, who provided comments on [GitHub issues](https://github.com/greenelab/scihub/issues) or pull requests.
 Specifically, the following individuals provided valuable input while the study was underway:
-[Richard Smith-Unna](https://github.com/blahah),
-[Ross Mounce](https://github.com/rossmounce),
-and [Guillaume Cabanac](https://github.com/gcabanac).
+[Thomas Munro](https://github.com/tamunro) and by extension his [appointment](http://www.deakin.edu.au/about-deakin/people/thomas-munro) at Deakin University, [Ross Mounce](https://github.com/rossmounce), [Richard Smith-Unna](https://github.com/blahah), and [Guillaume Cabanac](https://github.com/gcabanac).
 In addition, we're grateful to GitHub for offering gratis Large File Storage as part of their education program.
 
 ## References {.page_break_before}


### PR DESCRIPTION
Adds acknowledgement to Thomas Munro (@tamunro), who's been active and helpful [via GitHub Issues](https://github.com/greenelab/scihub-manuscript/search?q=tamunro&type=Issues&utf8=%E2%9C%93).

@tamunro does the Deakin University reference look good to you? Suggestions welcome