### PR TITLE
fix typo noticed in crlive slide

### DIFF
--- a/content/01.manuscript.md
+++ b/content/01.manuscript.md
@@ -292,7 +292,7 @@ Therefore, we used recent citations to estimate Sci-Hub's coverage of articles w
 We identified 7,312,607 outgoing citations from articles published since 2015.
 6,657,410 of the recent citations (91.0%) referenced an article that is in Sci-Hub.
 However, if only considering the 6,252,279 citations to articles in toll access journals, Sci-Hub covers 96.2% of recent citations.
-On the other hand, for the 858,583 citations to articles in open access journals, Sci-Hub's covers only 62.4%.
+On the other hand, for the 858,583 citations to articles in open access journals, Sci-Hub covers only 62.4%.
 
 ### Sci-Hub access logs
 

--- a/content/01.manuscript.md
+++ b/content/01.manuscript.md
@@ -292,7 +292,7 @@ Therefore, we used recent citations to estimate Sci-Hub's coverage of articles w
 We identified 7,312,607 outgoing citations from articles published since 2015.
 6,657,410 of the recent citations (91.0%) referenced an article that is in Sci-Hub.
 However, if only considering the 6,252,279 citations to articles in toll access journals, Sci-Hub covers 96.2% of recent citations.
-On the other, for the 858,583 citations to articles in open access journals, Sci-Hub's covers only 62.4%.
+On the other hand, for the 858,583 citations to articles in open access journals, Sci-Hub's covers only 62.4%.
 
 ### Sci-Hub access logs
 


### PR DESCRIPTION
Magdalena M. Grabowska (http://casemed.case.edu/dept/urology/BioGrabowska.cfm) noticed a typo in the slide that I tweeted. It turns out the typo comes from the underlying text. I'm fixing it in the slide. This PR also fixes it in the text.