### PR TITLE
Improve LibGen scimag comparison to Cabanac dump

### DIFF
--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -52,9 +52,9 @@ If Sci-Hub's coverage is sufficiently broad, then a radical shift may be underwa
 Weekly interest from Google Trends is plotted over time for the search terms "Sci-Hub" and "LibGen".
 The light green period indicates when Sci-Hub used LibGen as its database for storing articles [@url:https://engineuring.wordpress.com/2017/07/02/some-facts-on-sci-hub-that-wikipedia-gets-wrong/].
 The light blue period indicates the public availability of access logs from Sci-Hub [@doi:10.5061/dryad.q447c/1].
-The first pink dotted line represents the collection date of the LibGen metadata used in Cabanac's study [@doi:10.1002/asi.23445; @doi:10.6084/m9.figshare.4906367.v1].
+The first pink dotted line represents the collection date of the LibGen scimag metadata used in Cabanac's study [@doi:10.1002/asi.23445; @doi:10.6084/m9.figshare.4906367.v1].
 The second pink dotted line shows the date of Sci-Hub's tweeted DOI catalog used in this study.
-](https://cdn.rawgit.com/greenelab/scihub/65a06a516b4299ffbcd4c28dc2f75bbae8c553fc/explore/trends/google-trends.png){#fig:history width="100%"}
+](https://cdn.rawgit.com/greenelab/scihub/db8866f8ba629a74dc5779698dc5f451571d8b4c/explore/trends/google-trends.png){#fig:history width="100%"}
 
 In Figure @fig:history, The ⓛⓔⓣⓣⓔⓡⓢ refer to the following events:
 
@@ -532,8 +532,8 @@ After removing records missing `TimeAdded`, 64,195,940 DOIs remained.
 The 12.4% of LibGen scimag DOIs missing from our Crossref catalog likely comprise incorrect DOIs, DOIs whose metadata availability postdates our Crossref export, DOIs from other Registration Agencies, and DOIs for excluded publication types.
 
 Next, we explored the cumulative size of LibGen scimag over time according to the `TimeAdded` field (Figure @fig:libgen-size).
-However, when we [compared](https://github.com/greenelab/scihub/issues/8#issuecomment-296710357) our plot to one generated from the LibGen scimag database SQL dump on January 5, 2014 [@doi:10.1002/asi.23445; @doi:10.6084/m9.figshare.4906367.v1], we noticed a major discrepancy.
-The earlier analysis identified a total of 22,829,088 DOIs, whereas we found only 234,504 DOIs as of January 5, 2014.
+However, when we compared our plot to one generated from the LibGen scimag database SQL dump on January 1, 2014 [@doi:10.1002/asi.23445; @doi:10.6084/m9.figshare.4906367.v1], we noticed a major discrepancy.
+The earlier analysis identified a total of 22,829,088 DOIs, whereas we found only 233,707 DOIs as of January 1, 2014.
 We hypothesize that the discrepancy arose because `TimeAdded` indicates the date modified rather than created.
 Specifically, when an article in the database is changed, the database record for that DOI is entirely replaced.
 Hence, the `TimeAdded` value is effectively overwritten upon every update to a record.
@@ -549,16 +549,12 @@ It is likely that such massive collections of articles result from biblioleaks [
 While we agree this is most likely the case, confirmation is needed that the bulk addition of articles does not simply correspond to bulk updates rather than bulk initial uploads.
 
 ![
-**Lag-time from publication to LibGen upload.**
-For each year of publication from 2010–2017, we plot the relationship between lag-time and LibGen scimag's coverage.
-For example, this plot shows that 75% of articles published in 2011 were uploaded to LibGen within 60 months.
-This analysis only considers articles for which a month of publication can reliably be extracted, which excludes all articles that are allegedly published on the first day of each year.
-This plot portrays lag-times as decreasing over time, with maximum coverage declining.
-For example, coverage for 2016 articles exceeded 50% within 6 months, but appears to have reached an asymptote around 60%.
-Alternatively, coverage for 2014 took 15 months to exceed 50%, but has since reached 75%.
-However, this signal could result from post-dated LibGen upload timestamps (see Figure @fig:libgen-size).
-Therefore, we caution against drawing any conclusions from the `TimeAdded` field in LibGen scimag until its accuracy can be established more reliably.
-](https://cdn.rawgit.com/greenelab/scihub/7891082161dbcfcd5eeb1d7b76ee99ab44b95064/figure/libgen-monthly-lagtimes.svg){#fig:libgen-lag width="100%"}
+**Number of articles in LibGen scimag over time.**
+The figure shows the number of articles in LibGen scimag, according to its `TimeAdded` field, for two database dumps. 
+The number of articles added per day for the January 1, 2014 LibGen database dump was [provided](https://github.com/greenelab/scihub/issues/8#issuecomment-296719787) by Cabanac and corresponds to Figure 1 of @doi:10.1002/asi.23445.
+Notice the major discrepancy whereby articles from the April 7, 2017 database dump were added at later dates.
+Accordingly, we hypothesize that the `TimeAdded` field is replaced upon modification, making it impossible to assess date of first upload.
+](https://cdn.rawgit.com/greenelab/scihub/db8866f8ba629a74dc5779698dc5f451571d8b4c/figure/libgen-cumulative-works.svg){#fig:libgen-size width="4in"}
 
 ### Sci-Hub's catalog of articles
 
@@ -641,8 +637,13 @@ Donations in USD refers to the United States dollar value at time of transaction
 ](https://cdn.rawgit.com/greenelab/scihub/357ddf3153b7897ba5a443c7cb241cf3eb65e8cb/explore/bitcoin/monthly-donations-faceted.svg){#fig:bitcoin-all tag="10—figure supplement 1" width="5in"}
 
 ![
-**Number of articles in LibGen scimag over time.**
-The figure shows the cumulative number of articles versus the LibGen scimag `TimeAdded` field.
-When comparing this plot to Figure 1 of @doi:10.1002/asi.23445, we noticed a major discrepancy.
-We hypothesize that the `TimeAdded` field is replaced upon modification, making it impossible to assess date of first upload.
-](https://cdn.rawgit.com/greenelab/scihub/ca4d523e149f30be7fd3d3ae6551a26d1c625313/figure/libgen-cumulative-works.svg){#fig:libgen-size tag="11—figure supplement 1" width="4in"}
+**Lag-time from publication to LibGen upload.**
+For each year of publication from 2010–2017, we plot the relationship between lag-time and LibGen scimag's coverage.
+For example, this plot shows that 75% of articles published in 2011 were uploaded to LibGen within 60 months.
+This analysis only considers articles for which a month of publication can reliably be extracted, which excludes all articles that are allegedly published on the first day of each year.
+This plot portrays lag-times as decreasing over time, with maximum coverage declining.
+For example, coverage for 2016 articles exceeded 50% within 6 months, but appears to have reached an asymptote around 60%.
+Alternatively, coverage for 2014 took 15 months to exceed 50%, but has since reached 75%.
+However, this signal could result from post-dated LibGen upload timestamps.
+Therefore, we caution against drawing any conclusions from the `TimeAdded` field in LibGen scimag until its accuracy can be established more reliably.
+](https://cdn.rawgit.com/greenelab/scihub/db8866f8ba629a74dc5779698dc5f451571d8b4c/figure/libgen-monthly-lagtimes.svg){#fig:libgen-lag tag="11—figure supplement 1" width="100%"}

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -132,4 +132,4 @@ TODO
 For example, Figure S2 could become Figure 10-Figure Supplement 1.
 
 We converted supplementary figures into figure supplements.
-We moved Figure S4 into the Methods section of the main text.
+We moved Figure S3 into the Methods section of the main text.


### PR DESCRIPTION
Add Cabanac line to the LibGen scimag size figure.

Update Cabanac LibGen scimag database dump date from 2014-01-05 to 2014-01-01 as per https://twitter.com/gcabanac/status/953730398600736771. Refs https://github.com/greenelab/scihub/commit/db8866f8ba629a74dc5779698dc5f451571d8b4c

Put LibGen scimag size in main text and faulty lag-time analysis as a figure supplement.

Refs https://github.com/greenelab/scihub/issues/8