### PR TITLE
Adding Jacob Levernier as author

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -33,6 +33,14 @@ author_info:
     affiliations:
       - Bidwise, Inc
   -
+    github: publicus
+    name: Jacob G. Levernier
+    initials: JGL
+    orcid: 0000-0003-1563-7314
+    email: jlevern@upenn.edu
+    affiliations:
+      - Library Technology Services and Strategic Initiatives, University of Pennsylvania Libraries
+  -
     github: tamunro
     name: Thomas Anthony Munro
     initials: TAM


### PR DESCRIPTION
At @dhimmel's request via email, I have added myself as an author to the manuscript.

I don't have a Twitter account, nor a funder code (though I'm not sure what the latter is for in this case), and so left those lines out.