### PR TITLE
Add library access results

### DIFF
--- a/content/01.abstract.md
+++ b/content/01.abstract.md
@@ -3,6 +3,7 @@
 The website Sci-Hub enables users to download PDF versions of scholarly articles, including many articles that are paywalled at their journal's site.
 Sci-Hub has grown rapidly since its creation in 2011, but the extent of its coverage was unclear.
 Here we report that, as of March 2017, the Sci-Hub database contains 68.9% of the 81.6 million scholarly articles registered with Crossref and 85.2% of articles published in toll access journals.
-We find that coverage varies by discipline and publisher, that Sci-Hub preferentially covers popular, paywalled content, and that gaps in Sci-Hub's coverage can be filled using licit services such as oaDOI.
+We find that coverage varies by discipline and publisher and that Sci-Hub preferentially covers popular, paywalled content.
+For toll access articles, green open access via licit services is quite limited, while Sci-Hub provides greater coverage than a major research university.
 Our interactive browser at https://greenelab.github.io/scihub allows users to explore these findings in more detail.
 For the first time, nearly all scholarly literature is available gratis to anyone with an Internet connection, suggesting the toll access business model will become unsustainable.

--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -568,7 +568,7 @@ Note that Scopus does not index every scholarly journal [@doi:10.1007/s11192-015
 
 We tidied the Scopus Journal Metrics, which evaluate journals based on the number of citations their articles receive.
 Specifically, we extracted a 2015 CiteScore for 22,256 titles, 17,336 of which were included in our journal catalog.
-Finally, we queried the Elsevier API to [retrieve](https://github.com/dhimmel/scopu/issues/2) homepage URLs for 20,992 Scopus titles.
+Finally, we queried the Elsevier API to [retrieve](https://github.com/dhimmel/scopus/issues/2) homepage URLs for 20,992 Scopus titles.
 See [dhimmel/scopus](https://github.com/dhimmel/scopus) for the source code and data relating to Scopus.
 
 ### LibGen scimag's catalog of articles

--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -288,19 +288,19 @@ According to the Higher Education Research and Development Survey, [R&D expendit
 In 2017, Penn Libraries [approximates](https://github.com/greenelab/library-access/issues/23) that it spent $13.13 million on electronic resources, which includes subscriptions to journals and ebooks.
 During this year, its users accessed 7.3 million articles and 860 thousand ebook chapters, averaging a per-download cost of $1.61.
 
-Penn Libraries uses the Ex Libris collection management software to provide a service called [PennText](https://upenn.alma.exlibrisgroup.com/discovery/citationlinker?vid=01UPENN_INST:Services&lang=en) to lookup scholarly articles.
+Penn Libraries uses the Ex Libris collection management software to provide a service called [PennText](https://upenn.alma.exlibrisgroup.com/discovery/citationlinker?vid=01UPENN_INST:Services&lang=en) for looking up scholarly articles.
 The service indicates whether an article's fulltext is available online, taking into account Penn's digital subscriptions.
 Using API calls to PennText's OpenURL resolver, we retrieved Penn's access status for the 290,120 articles analyzed by the State of OA study (see the [greenelab/library-access](https://github.com/greenelab/library-access) repository).
 We randomly selected 500 of these articles for manual evaluation and assessed whether their fulltexts were available within Penn's network as well as outside of any institutional network.
 We defined access as fulltext availability at the location redirected to by an article's DOI, without providing any payment, credentials, or login information.
-This definition is analogous to the union of oaDOI's gold, hybrid, and bronze classifications.
+This definition is analogous to the union of oaDOI's gold, hybrid, and bronze categories.
 
 Using these manual access calls, we [found](https://github.com/greenelab/library-access/blob/c60246a0dd6b0fccf9b1954f793261e729954b66/evaluate_library_access_from_output_tsv/penntext-accuracy-500.ipynb) PennText correctly classified access 88.2% of the time.
 PennText claimed to have access to 422 of the 500 articles (84.4%).
 When PennText asserted access, it was correct 94.8% of the time.
 However, when PennText claimed no access, it was only correct for 41 of 78 articles (52.6%).
-This was because PennText was not only unaware of Penn's access to 23 open articles, but also unaware of Penn's subscription access to 14 articles.
-Despite these issues, PennText's estimate of Penn's access at 84.4% did not drastically differ from the manually verified estimate of 87.4%.
+This error rate arose because PennText was not only unaware of Penn's access to 23 open articles, but also unaware of Penn's subscription access to 14 articles.
+Despite these issues, PennText's estimate of Penn's access at 84.4% did not drastically differ from the manually evaluated estimate of 87.4%.
 Nonetheless, we proceed by showing comparisons for both the 500 articles with manual access calls as well as the 290,120 articles with PennText calls.
 
 ### Coverage combining access methods
@@ -332,15 +332,15 @@ Our findings suggest that users with institutional subscriptions and knowledge o
 
 ![
 **Coverage of several access methods and their combinations.**
-This figure considers compares datasets of accessible articles corresponding to various access methods.
-These article sets refer to manually verified access via the publisher's site from outside of an institutional network (labeled None) or from inside Penn's network (labeled Penn);
-access according to Penn's library system (labeled PennText, not manually verified);
+This figure compares datasets of article coverage corresponding to various access methods.
+These article sets refer to manually evaluated access via the publisher's site from outside of an institutional network (labeled None) or from inside Penn's network (labeled Penn);
+access according to Penn's library system (labeled PennText);
 access via oaDOI (labeled oaDOI);
 and inclusion in Sci-Hub's database (labeled Sci-Hub).
 Each diagram shows the coverage of three access methods and their possible combinations.
 Within a diagram, each section notes the percent coverage achieved by the corresponding combination of access methods.
-Contrary to traditional Venn diagrams, each section does not contain disjoint sets of articles.
-Instead, each section shows coverage on the same set of articles indicated in the diagram's title.
+Contrary to traditional Venn diagrams, each section does not indicate disjoint sets of articles.
+Instead, each section shows coverage on the same set of articles, whose total number is reported in the diagram's title.
 The top two diagrams show coverage on a small set of manually evaluated articles.
 The bottom two diagrams show coverage on a larger set of automatically evaluated articles.
 The two lefthand diagrams show coverage on all articles, whereas the two righthand diagrams show coverage on toll access articles only.

--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -260,37 +260,95 @@ However, articles in toll access journals may also be available without charge.
 Adopting the terminology from the recent "State of OA" study [@doi:10.7287/peerj.preprints.3119v1], articles in toll access journals may be available gratis from the publisher under a license that permits use (termed "hybrid") or with all rights reserved (termed "bronze").
 Alternatively, "green" articles are paywalled on the publisher's site, but available gratis from an open access repository (e.g. a pre- or post-print server, excluding Sci-Hub and academic social networks).
 
-The State of OA study compiled three collections of articles (see [Methods](#state-of-oa-datasets)) and assigned each article an access status using their oaDOI utility.
-Figure {@fig:state-of-oa}A shows Sci-Hub's coverage for each category of access status.
-In line with our findings on the entire Crossref article catalog where Sci-Hub covered 49.1% of articles in open access journals, Sci-Hub's coverage on gold articles in the State of OA's Crossref collection was 47.8%.
-Impressively, Sci-Hub's coverage of the closed articles in the Web of Science collection was 97.8%.
-This remarkable coverage likely reflects that these articles were published from 2009–2015 and classified as citable items by Web of Science, which is selective when indexing journals [@doi:10.1007/s11192-015-1765-5].
+The State of OA study determined the access status of 290,120 articles using the oaDOI utility (see [Methods](#state-of-oa-datasets)).
+Figure @fig:oadoi shows Sci-Hub's coverage for each category of access status.
+In line with our findings on the entire Crossref article catalog where Sci-Hub covered 49.1% of articles in open access journals, Sci-Hub's coverage of gold articles in the State of OA's dataset was 49.2%.
+Coverage of the 165,340 closed articles was 90.4%.
 
-For all three collections, Sci-Hub's coverage was higher for closed and green articles than for hybrid or bronze articles. 
-Furthermore, Sci-Hub's coverage of closed articles was similar to its coverage of green articles (Figure {@fig:state-of-oa}A).
+![
+**Sci-Hub's coverage by oaDOI access status.**
+Using oaDOI calls from the State of OA study, we show Sci-Hub's coverage on each access status.
+Gray indicates articles that were not accessible via oaDOI (referred to as closed).
+Here, all three State of OA collections were combined, yielding 290,120 articles.
+Figure @fig:oadoi-large shows coverage separately for the three State of OA collections.
+](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/state-of-oa-colors-small.svg){#fig:oadoi width="70%"}
+
+Sci-Hub's coverage was higher for closed and green articles than for hybrid or bronze articles.
+Furthermore, Sci-Hub's coverage of closed articles was similar to its coverage of green articles (Figure @fig:oadoi).
 These findings suggest a historical pattern where users resort to Sci-Hub after encountering a paywall but before checking oaDOI or a search engine for green access.
 As such, Sci-Hub receives requests for green articles, triggering it to retrieve green articles at a similar rate to closed articles.
 However, hybrid and bronze articles, which are available gratis from their publisher, are requested and thus retrieved at a lower rate.
 
-![
-**Coverage on the State of OA datasets.**
-**A)** Sci-Hub's coverage by category of oaDOI access type.
-Color indicates accessibility status.
-Gray indicates closed (not accessible via oaDOI).
-**B)** Coverage of oaDOI, Sci-Hub, and the combination of both repositories.
-](https://cdn.rawgit.com/greenelab/scihub/ca4d523e149f30be7fd3d3ae6551a26d1c625313/figure/state-of-oa.svg){#fig:state-of-oa width="100%"}
+### Coverage of Penn Libraries
 
-### oaDOI Coverage
+As a benchmark, we decided to compare Sci-Hub's coverage to the access provided by a major research library.
+Since we were unaware of any studies that comprehensively profiled library access to scholarly articles, we collaborated with Penn Libraries to assess the extent of access available at the University of Pennsylvania (Penn).
+Penn is a private research university located in Philadelphia, which was founded by the open science pioneer Benjamin Franklin in 1749.
+According to the Higher Education Research and Development Survey, [R&D expenditures](https://ncsesdata.nsf.gov/herd/2016/html/HERD2016_DST_21.html "Table 21. Higher education R&D expenditures, ranked by all R&D expenditures, by source of funds: FY 2016") at Penn totaled $1.29 billion in 2016, placing it third among U.S. colleges and universities.
+In 2017, Penn Libraries approximates that it spent $13.13 million on electronic resources, which includes subscriptions to journals and ebooks.
+During this year, its users accessed 7.3 million articles and 860 thousand ebook chapters, averaging a per-download cost of $1.61.
 
-[oaDOI](https://oadoi.org/) is a utility that redirects paywalled DOIs to gratis, licit versions, when possible [@doi:10.7287/peerj.preprints.3119v1].
-Like Sci-Hub, oaDOI is used to find gratis access to fulltext scholarly articles.
-Figure {@fig:state-of-oa}B shows oaDOI's coverage on the three State of OA article collections.
-Note that oaDOI has complete coverage of all access categories besides closed, where it has zero coverage.
-Alone oaDOIs coverage is limited: below 50% on every collection due to the large number of closed articles where it could not locate gratis access.
-However, oaDOI's coverage greatly complements Sci-Hub's coverage, with combined coverage exceeding 89% for each of the three collections.
-On the Web of Science collection, combining Sci-Hub's 92.9% coverage with oaDOIs 36.0% coverage yielded 98.6% coverage.
-On the Unpaywall collection, which best reflects the access needs of contemporary scholars, combined coverage was 94.1%.
+Penn Libraries uses the Ex Libris collection management software to provide a service called [PennText](https://upenn.alma.exlibrisgroup.com/discovery/citationlinker?vid=01UPENN_INST:Services&lang=en) to lookup scholarly articles.
+The service indicates whether an article's fulltext is available online, taking into account Penn's digital subscriptions.
+Using API calls to PennText's OpenURL resolver, we retrieved Penn's access status for the 290,120 articles analyzed by the State of OA study.
+We randomly selected 500 of these articles for manual evaluation and assessed whether their fulltexts were available within Penn's network as well as outside of any institutional network.
+We defined access as fulltext availability at the location redirected to by an article's DOI, without providing any payment, credentials, or login information.
+This definition includes the gold, hybrid, and bronze oaDOI classifications, but not green and closed.
+
+Using these manual access calls, we found PennText correctly classified access 88.2% of the time.
+Overall, PennText claimed access for 422 articles, of which Penn had access to 94.8%.
+However, PennText claimed not to have access for 78 articles, of which Penn actually did have access to 47.4%.
+For the 174 articles available off campus, PennText claimed to have access to 151 (86.8% accuracy).
+For the 263 articles available on but not off campus, PennText claimed to have access to 249 (94.7% accuracy).
+For the 63 articles not available on campus, PennText claimed to have access to 22 (65.1% accuracy).
+Accordingly, the collection management software at Penn is oftentimes unaware of Penn's actual access, even in cases where Penn appears to have subscription access.
+Given the error rate of PennText, we proceed by showing comparisons for both the 500 articles with manual access calls as well as the 290,120 articles with PennText calls.
+
+PennText claimed to have access to 422 of the 500 articles (84.4%).
+When PennText asserted access, it was correct 94.8% of the time.
+However when PennText claimed no access, it was only correct for 41 of 78 articles (52.6%).
+This was because PennText was unaware of access to many open articles as well many subscription articles.
+
+### Coverage combining access methods
+
+In practice, readers of the scholarly literature likely use a variety of methods for access.
+Figure @fig:combinations compares several of these methods, as well as their combinations.
+First, users may simply attempt to view an article on its publisher's site from a network without any institutional access.
+Based on our manual evaluation of 500 articles, we found 34.8% of articles are accessible this way.
+The remaining 326 articles that are not accessible from their publisher's site are presumed to be toll access.
+[oaDOI](https://oadoi.org/) --- a utility that redirects paywalled DOIs to gratis, licit versions, when possible [@doi:10.7287/peerj.preprints.3119v1] --- was able to access 15.3% of these toll access articles, indicating that green open access is still limited in its reach.
+On the full set of 208,786 toll access articles in the State of OA dataset, oaDOI only provides access to 12.4%.
+Therefore, although oaDOI's overall access rate was 37.0%, the majority of the articles oaDOI accessed were gratis on their publisher's site, and therefore oaDOI was not essential for access.
+
+Sci-Hub and Penn have similar coverage on all articles:
+85.2% versus 87.4% respectively on the manually-evaluated articles and 84.8% versus 84.4% on the larger but automated set.
+However, when considering only toll access articles, Sci-Hub's coverage exceeds Penn's: 
+94.2% versus 80.7% on the manual set and 90.7% versus 83.5% on the automated set.
+This reflects Sci-Hub's focus on paywalled articles.
+In addition, Sci-Hub's coverage is a lower bound for its access rate, since it can retrieve articles on demand, so in practice Sci-Hub's access to toll access articles could exceed Penn's by a higher margin.
+Combining access methods can also be synergistic.
+For example, we find on the manual set that 96.2% of articles were available on their publisher's site or in Sci-Hub's database.
+Adding Penn's access to the mix, increased coverage to 98.2%.
+For those who are already using Penn or Sci-Hub to access articles, oaDOI contributes little additional coverage, approximately 1%, according to the automated set of 208,786 toll access articles.
 In short, deficits in Sci-Hub's coverage are largely made up for when considering licit access routes.
+
+![
+**Coverage of several access methods and their combinations.**
+This figure considers compares datasets of accessible articles corresponding to various access methods.
+These article sets refer to manually verified access via the publisher's site from outside of an institutional network (labeled None) or from inside Penn's network (labeled Penn);
+access according to Penn's library system (labeled PennText, not manually verified);
+access via oaDOI (labeled oaDOI);
+and inclusion in Sci-Hub's database (labeled Sci-Hub).
+Each diagram shows the coverage of three access methods and their possible combinations.
+Within a diagram, each section notes the percent coverage achieved by the corresponding combination of access methods.
+Contrary to traditional Venn diagrams, each section does not contain disjoint sets of articles.
+Instead, each section shows coverage on the same set of articles indicated in the diagram's title.
+The top two diagrams show coverage on a small set of manually evaluated articles.
+The bottom two diagrams show coverage on a larger set of automatically evaluated articles.
+The two lefthand diagrams show coverage on all articles, whereas the two righthand diagrams show coverage on toll access articles only.
+Specifically, the top-right diagram assesses coverage on articles that were inaccessible from outside of an institutional network.
+Similarly, the bottom-right diagram assesses coverage of articles that were classified as closed or green by oaDOI, and thus excludes gold, hybrid, and bronze articles (those available gratis from their publisher).
+](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/library-access-venns-small.svg){#fig:combinations width="70%"}
 
 ### Coverage of recently cited articles
 
@@ -631,10 +689,20 @@ Sci-Hub's coverage is shown for countries with at least 100,000 articles.
 ](https://cdn.rawgit.com/greenelab/scihub/ca4d523e149f30be7fd3d3ae6551a26d1c625313/figure/coverage-by-country.svg){#fig:countries tag="4—figure supplement 1" width="100%"}
 
 ![
+**Coverage by oaDOI access status on each State of OA collection.**
+Coverage by oaDOI access status is shown for Sci-Hub, PennText, and the union of Sci-Hub and PennText.
+Each panel refers to a different State of OA collection, with Combined referring to the union of Crossref, Unpaywall, and Web of Science.
+The Sci-Hub section of the Combined panel is the same as Figure @fig:oadoi.
+Impressively, Sci-Hub’s coverage of the closed articles in the Web of Science collection was 97.8%.
+This remarkable coverage likely reflects that these articles were published from 2009–2015 and classified as citable items by Web of Science, which is selective when indexing journals [@doi:10.1007/s11192-015-1765-5].
+Note that PennText does not have complete coverage of bronze, hybrid, and gold articles, which should be the case were all metadata systems perfect.
+](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/state-of-oa-colors-large.svg){#fig:oadoi-large tag="8—figure supplement 1" width="100%"}
+
+![
 **Bitcoin donations to Sci-Hub per month.**
 For months since June 2015, total bitcoin donations (deposits to known Sci-Hub addresses) are assessed.
 Donations in USD refers to the United States dollar value at time of transaction confirmation.
-](https://cdn.rawgit.com/greenelab/scihub/357ddf3153b7897ba5a443c7cb241cf3eb65e8cb/explore/bitcoin/monthly-donations-faceted.svg){#fig:bitcoin-all tag="10—figure supplement 1" width="5in"}
+](https://cdn.rawgit.com/greenelab/scihub/357ddf3153b7897ba5a443c7cb241cf3eb65e8cb/explore/bitcoin/monthly-donations-faceted.svg){#fig:bitcoin-all tag="11—figure supplement 1" width="5in"}
 
 ![
 **Lag-time from publication to LibGen upload.**
@@ -646,4 +714,4 @@ For example, coverage for 2016 articles exceeded 50% within 6 months, but appear
 Alternatively, coverage for 2014 took 15 months to exceed 50%, but has since reached 75%.
 However, this signal could result from post-dated LibGen upload timestamps.
 Therefore, we caution against drawing any conclusions from the `TimeAdded` field in LibGen scimag until its accuracy can be established more reliably.
-](https://cdn.rawgit.com/greenelab/scihub/db8866f8ba629a74dc5779698dc5f451571d8b4c/figure/libgen-monthly-lagtimes.svg){#fig:libgen-lag tag="11—figure supplement 1" width="100%"}
+](https://cdn.rawgit.com/greenelab/scihub/db8866f8ba629a74dc5779698dc5f451571d8b4c/figure/libgen-monthly-lagtimes.svg){#fig:libgen-lag tag="12—figure supplement 1" width="100%"}

--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -285,29 +285,23 @@ As a benchmark, we decided to compare Sci-Hub's coverage to the access provided 
 Since we were unaware of any studies that comprehensively profiled library access to scholarly articles, we collaborated with Penn Libraries to assess the extent of access available at the University of Pennsylvania (Penn).
 Penn is a private research university located in Philadelphia, which was founded by the open science pioneer Benjamin Franklin in 1749.
 According to the Higher Education Research and Development Survey, [R&D expenditures](https://ncsesdata.nsf.gov/herd/2016/html/HERD2016_DST_21.html "Table 21. Higher education R&D expenditures, ranked by all R&D expenditures, by source of funds: FY 2016") at Penn totaled $1.29 billion in 2016, placing it third among U.S. colleges and universities.
-In 2017, Penn Libraries approximates that it spent $13.13 million on electronic resources, which includes subscriptions to journals and ebooks.
+In 2017, Penn Libraries [approximates](https://github.com/greenelab/library-access/issues/23) that it spent $13.13 million on electronic resources, which includes subscriptions to journals and ebooks.
 During this year, its users accessed 7.3 million articles and 860 thousand ebook chapters, averaging a per-download cost of $1.61.
 
 Penn Libraries uses the Ex Libris collection management software to provide a service called [PennText](https://upenn.alma.exlibrisgroup.com/discovery/citationlinker?vid=01UPENN_INST:Services&lang=en) to lookup scholarly articles.
 The service indicates whether an article's fulltext is available online, taking into account Penn's digital subscriptions.
-Using API calls to PennText's OpenURL resolver, we retrieved Penn's access status for the 290,120 articles analyzed by the State of OA study.
+Using API calls to PennText's OpenURL resolver, we retrieved Penn's access status for the 290,120 articles analyzed by the State of OA study (see the [greenelab/library-access](https://github.com/greenelab/library-access) repository).
 We randomly selected 500 of these articles for manual evaluation and assessed whether their fulltexts were available within Penn's network as well as outside of any institutional network.
 We defined access as fulltext availability at the location redirected to by an article's DOI, without providing any payment, credentials, or login information.
-This definition includes the gold, hybrid, and bronze oaDOI classifications, but not green and closed.
+This definition is analogous to the union of oaDOI's gold, hybrid, and bronze classifications.
 
-Using these manual access calls, we found PennText correctly classified access 88.2% of the time.
-Overall, PennText claimed access for 422 articles, of which Penn had access to 94.8%.
-However, PennText claimed not to have access for 78 articles, of which Penn actually did have access to 47.4%.
-For the 174 articles available off campus, PennText claimed to have access to 151 (86.8% accuracy).
-For the 263 articles available on but not off campus, PennText claimed to have access to 249 (94.7% accuracy).
-For the 63 articles not available on campus, PennText claimed to have access to 22 (65.1% accuracy).
-Accordingly, the collection management software at Penn is oftentimes unaware of Penn's actual access, even in cases where Penn appears to have subscription access.
-Given the error rate of PennText, we proceed by showing comparisons for both the 500 articles with manual access calls as well as the 290,120 articles with PennText calls.
-
+Using these manual access calls, we [found](https://github.com/greenelab/library-access/blob/c60246a0dd6b0fccf9b1954f793261e729954b66/evaluate_library_access_from_output_tsv/penntext-accuracy-500.ipynb) PennText correctly classified access 88.2% of the time.
 PennText claimed to have access to 422 of the 500 articles (84.4%).
 When PennText asserted access, it was correct 94.8% of the time.
-However when PennText claimed no access, it was only correct for 41 of 78 articles (52.6%).
-This was because PennText was unaware of access to many open articles as well many subscription articles.
+However, when PennText claimed no access, it was only correct for 41 of 78 articles (52.6%).
+This was because PennText was not only unaware of Penn's access to 23 open articles, but also unaware of Penn's subscription access to 14 articles.
+Despite these issues, PennText's estimate of Penn's access at 84.4% did not drastically differ from the manually verified estimate of 87.4%.
+Nonetheless, we proceed by showing comparisons for both the 500 articles with manual access calls as well as the 290,120 articles with PennText calls.
 
 ### Coverage combining access methods
 

--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -271,7 +271,7 @@ Using oaDOI calls from the State of OA study, we show Sci-Hub's coverage on each
 Gray indicates articles that were not accessible via oaDOI (referred to as closed).
 Here, all three State of OA collections were combined, yielding 290,120 articles.
 Figure @fig:oadoi-large shows coverage separately for the three State of OA collections.
-](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/state-of-oa-colors-small.svg){#fig:oadoi width="70%"}
+](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/state-of-oa-colors-small.svg){#fig:oadoi width="60%"}
 
 Sci-Hub's coverage was higher for closed and green articles than for hybrid or bronze articles.
 Furthermore, Sci-Hub's coverage of closed articles was similar to its coverage of green articles (Figure @fig:oadoi).
@@ -307,24 +307,28 @@ Nonetheless, we proceed by showing comparisons for both the 500 articles with ma
 
 In practice, readers of the scholarly literature likely use a variety of methods for access.
 Figure @fig:combinations compares several of these methods, as well as their combinations.
-First, users may simply attempt to view an article on its publisher's site from a network without any institutional access.
+Users without institutional access may simply attempt to view an article on its publisher's site.
 Based on our manual evaluation of 500 articles, we found 34.8% of articles are accessible this way.
-The remaining 326 articles that are not accessible from their publisher's site are presumed to be toll access.
+The remaining 326 articles that are not accessible from their publisher's site are considered toll access.
 [oaDOI](https://oadoi.org/) --- a utility that redirects paywalled DOIs to gratis, licit versions, when possible [@doi:10.7287/peerj.preprints.3119v1] --- was able to access 15.3% of these toll access articles, indicating that green open access is still limited in its reach.
-On the full set of 208,786 toll access articles in the State of OA dataset, oaDOI only provides access to 12.4%.
-Therefore, although oaDOI's overall access rate was 37.0%, the majority of the articles oaDOI accessed were gratis on their publisher's site, and therefore oaDOI was not essential for access.
+This remained true on the full set of 208,786 toll access articles from the State of OA dataset, where oaDOI only provided access to 12.4%.
+Although oaDOI's overall access rate was 37.0%, this access consisted largely of gold, hybrid, and bronze articles, whereby gratis access is provided by the publisher.
 
-Sci-Hub and Penn have similar coverage on all articles:
-85.2% versus 87.4% respectively on the manually-evaluated articles and 84.8% versus 84.4% on the larger but automated set.
+Sci-Hub and Penn had similar coverage on all articles:
+85.2% versus 87.4% on the manual article set and 84.8% versus 84.4% on larger but automated set.
 However, when considering only toll access articles, Sci-Hub's coverage exceeds Penn's: 
 94.2% versus 80.7% on the manual set and 90.7% versus 83.5% on the automated set.
 This reflects Sci-Hub's focus on paywalled articles.
 In addition, Sci-Hub's coverage is a lower bound for its access rate, since it can retrieve articles on demand, so in practice Sci-Hub's access to toll access articles could exceed Penn's by a higher margin.
+Remarkably, Sci-Hub provides greater access to toll access literature than a leading research university that spends millions of dollars per year for its access to scholarly literature.
+However, since Sci-Hub is able to retrieve articles through many university networks, it is perhaps unsurprising that its coverage exceeds that of a single university.
+
 Combining access methods can also be synergistic.
-For example, we find on the manual set that 96.2% of articles were available on their publisher's site or in Sci-Hub's database.
-Adding Penn's access to the mix, increased coverage to 98.2%.
-For those who are already using Penn or Sci-Hub to access articles, oaDOI contributes little additional coverage, approximately 1%, according to the automated set of 208,786 toll access articles.
-In short, deficits in Sci-Hub's coverage are largely made up for when considering licit access routes.
+Specifically when including open access articles, combining Sci-Hub's repository with oaDOI's or Penn's access increases coverage from around 85% to 95%.
+The benefits of oaDOI are reduced when only considering toll access articles, where oaDOI only improves Sci-Hub's or Penn's coverage by approximately 1%.
+On toll access articles, Penn's access appeared to complement Sci-Hub's.
+Together, Sci-Hub's repositories and Penn's access covered approximately 97% of toll access articles.
+Our findings suggest that users with institutional subscriptions and knowledge of oaDOI and Sci-Hub, are able to access over 97% of all articles, online and without payment.
 
 ![
 **Coverage of several access methods and their combinations.**
@@ -342,7 +346,7 @@ The bottom two diagrams show coverage on a larger set of automatically evaluated
 The two lefthand diagrams show coverage on all articles, whereas the two righthand diagrams show coverage on toll access articles only.
 Specifically, the top-right diagram assesses coverage on articles that were inaccessible from outside of an institutional network.
 Similarly, the bottom-right diagram assesses coverage of articles that were classified as closed or green by oaDOI, and thus excludes gold, hybrid, and bronze articles (those available gratis from their publisher).
-](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/library-access-venns-small.svg){#fig:combinations width="70%"}
+](https://cdn.rawgit.com/greenelab/scihub/58a60ffef1443d42eab9f163f9bb652ca2ddde25/figure/library-access-venns-small.svg){#fig:combinations width="60%"}
 
 ### Coverage of recently cited articles
 
@@ -409,6 +413,7 @@ In particular, users accessed articles from toll access journals much more frequ
 Additionally, within toll access journals, Sci-Hub provided higher coverage of articles in the closed and green categories (paywalled by the publisher) as opposed to the hybrid and bronze categories (available gratis from the publisher).
 Accordingly, many users likely only resort to Sci-Hub when access through a commercial database is cumbersome or costly.
 Finally, we observed evidence that Sci-Hub's primary operational focus is circumventing paywalls rather than compiling all literature, as archiving was deactivated in 2015 for several journals that exemplify openness.
+Attesting to its success in this mission, Sci-Hub's database already contains more toll access articles than are immediately accessible via the University of Pennsylvania, a leading research university.
 
 Judging from donations, many users appear to value Sci-Hub's service.
 In the past, Sci-Hub accepted donations through centralized and regulated payment processors such as PayPal, Yandex, WebMoney, and QiQi [@url:https://www.courtlistener.com/docket/4355308/1/elsevier-inc-v-sci-hub/; @url:https://www.courtlistener.com/docket/4355308/8/23/elsevier-inc-v-sci-hub/].

--- a/content/02.manuscript.md
+++ b/content/02.manuscript.md
@@ -569,7 +569,7 @@ Note that Scopus does not index every scholarly journal [@doi:10.1007/s11192-015
 
 We tidied the Scopus Journal Metrics, which evaluate journals based on the number of citations their articles receive.
 Specifically, we extracted a 2015 CiteScore for 22,256 titles, 17,336 of which were included in our journal catalog.
-Finally, we queried the Elsevier API to [retrieve](https://github.com/dhimmel/journalmetrics/issues/2) homepage URLs for 20,992 Scopus titles.
+Finally, we queried the Elsevier API to [retrieve](https://github.com/dhimmel/scopu/issues/2) homepage URLs for 20,992 Scopus titles.
 See [dhimmel/scopus](https://github.com/dhimmel/scopus) for the source code and data relating to Scopus.
 
 ### LibGen scimag's catalog of articles

--- a/content/response-to-reviewers.md
+++ b/content/response-to-reviewers.md
@@ -22,6 +22,12 @@ TODO: briefly summarize additional major changes since version 2 that are part o
 We updated our journal information to the October 2017 release of Scopus.
 In addition, we created patches to standardize publisher names in Scopus.
 As a result, many of the numbers reported in the manuscript have changed slightly.
+Thomas Munro assisted with the Scopus enhancements, as well as providing feedback in other areas, and has been added as an author.
+
+We investigated the level of access provided by the University of Pennsylvania Libraries.
+This is a major addition to the study, since it allows us to compare Sci-Hub's database with the access of a major research university.
+Furthermore, the data for this analysis are openly available, making it the most comprehensive public analysis of a university's coverage of the scholarly literature (that we're aware of).
+Jacob Levernier, who helped perform these analyses, has been added as an author.
 
 ## ESSENTIAL REVISIONS
 


### PR DESCRIPTION
- [x] Closes #21: comparison to authorized access
- [x] Refs #36: green + closed are now treated collectively as toll access in the coverage diagram